### PR TITLE
Add mass manufacturing mode

### DIFF
--- a/timcat/cost_model.py
+++ b/timcat/cost_model.py
@@ -22,6 +22,16 @@ def update_input_scaling(fname, case="Base"):
     # Create dictionary of parameters for the specific case
     scalars_dict = df_scalars.set_index("Parameter")[case + " value"].to_dict()
 
+    # Check for mass manufacturing parameters and add to scalars_dict
+    try:
+        if 'MassManufacturing' in pd.ExcelFile(fname).sheet_names:
+            mass_mfg_df = pd.read_excel(fname, sheet_name="MassManufacturing", index_col=0)
+            mass_mfg_params = mass_mfg_df.to_dict()[1]
+            scalars_dict.update(mass_mfg_params)
+            print("Mass manufacturing parameters loaded into scalars_dict")
+    except Exception as e:
+        print(f"Could not load mass manufacturing parameters: {e}")
+
     # Map the new values to the input df
     options = [0, 1, 2]
     for option in options:
@@ -96,6 +106,16 @@ def rand_input_scaling(fname):
 
     # Create dictionary of parameters for the specific case
     scalars_dict = df_scalars["New value"].to_dict()
+
+    # Check for mass manufacturing parameters and add to scalars_dict
+    try:
+        if 'MassManufacturing' in pd.ExcelFile(fname).sheet_names:
+            mass_mfg_df = pd.read_excel(fname, sheet_name="MassManufacturing", index_col=0)
+            mass_mfg_params = mass_mfg_df.to_dict()[1]
+            scalars_dict.update(mass_mfg_params)
+            print("Mass manufacturing parameters loaded into scalars_dict")
+    except Exception as e:
+        print(f"Could not load mass manufacturing parameters: {e}")
 
     # Map the new values to the input df
     options = [0, 1, 2]

--- a/timcat/ncet/fill_scaling_table.py
+++ b/timcat/ncet/fill_scaling_table.py
@@ -34,6 +34,24 @@ def fill_scaling_table(path, fname, base, scalars_dict, scaling_table=None):
         skiprows=[0],
         index_col=0,
     ).to_dict()[1]
+
+    # Check for mass manufacturing sheet and load parameters
+    try:
+        if 'MassManufacturing' in pd.ExcelFile(pjoin(path, fname)).sheet_names:
+            mass_mfg_df = pd.read_excel(
+                pjoin(path, fname),
+                sheet_name="MassManufacturing",
+                header=0,
+                index_col=0,
+            )
+            mass_mfg_params = mass_mfg_df.to_dict()[1]
+            plant_characteristics.update(mass_mfg_params)
+            print("Mass manufacturing mode detected and parameters loaded")
+        else:
+            plant_characteristics["Enable Mass Manufacturing"] = False
+    except Exception as e:
+        print(f"No mass manufacturing sheet found or error loading: {e}")
+        plant_characteristics["Enable Mass Manufacturing"] = False
     plant_characteristics["SPC One sided"] = []
     plant_characteristics["SPC Two sided"] = []
     plant_characteristics["SPC Area"] = []

--- a/timcat/ncet/learn.py
+++ b/timcat/ncet/learn.py
@@ -15,12 +15,26 @@ def learn(path, fname, dfNewPlant, orders, scalars_dict, idx_modules):
     dfNewPlant["Count per plant"].fillna(1, inplace=True)
 
     # learning rates and max cost reduction
-    fact_rate = scalars_dict["Factory learning rate"]  # 0.16
+    # Check for mass manufacturing mode
+    mass_mfg_enabled = scalars_dict.get("Enable Mass Manufacturing", False)
+
+    if mass_mfg_enabled:
+        print("Applying mass manufacturing learning curves")
+        # Use steeper learning rates for mass manufacturing
+        fact_rate = scalars_dict.get("Supply Chain Learning Rate", 0.25)
+        mat_rate = scalars_dict.get("Supply Chain Learning Rate", 0.25)
+        lab_rate = scalars_dict.get("Supply Chain Learning Rate", 0.25)
+        lab_min = scalars_dict.get("Mass Mfg Labor Minimum", 0.3)
+        mat_min = scalars_dict.get("Mass Mfg Material Minimum", 0.4)
+        print(f"Using learning rate: {fact_rate}, minimums: labor={lab_min}, material={mat_min}")
+    else:
+        # Use existing learning rates
+        fact_rate = scalars_dict["Factory learning rate"]  # 0.16
+        mat_rate = scalars_dict["Material learning rate"]  # 0.071
+        lab_rate = scalars_dict["Labor learning rate"]  # 0.131
+        lab_min = scalars_dict["Labor minimum"]  # 0.55
+        mat_min = scalars_dict["Material minimum"]  # 0.73
     fact_N0 = 100
-    mat_rate = scalars_dict["Material learning rate"]  # 0.071
-    lab_rate = scalars_dict["Labor learning rate"]  # 0.131
-    lab_min = scalars_dict["Labor minimum"]  # 0.55
-    mat_min = scalars_dict["Material minimum"]  # 0.73
     mat_learning_factor = np.maximum(
         mat_min, plants ** np.log2(1 - mat_rate)
     )  # learning rate at  9%, max reduction 27%

--- a/timcat/ncet/modularize.py
+++ b/timcat/ncet/modularize.py
@@ -3,55 +3,94 @@ from os.path import join as pjoin
 
 
 def modularize(path, fname, dfNewPlant, orders, scalars_dict):
-
     print("Modularizing accounts")
-    modules = pd.read_excel(
-        pjoin(path, fname), header=0, sheet_name="Modules", index_col="Account"
-    )
-    accounts = modules.index
-    fact_costs = (
-        modules["Factory Cost (2018 USD)"].values * scalars_dict["Factory cost mult"]
-    )
-    offsite_work = (
-        modules["Percent Offsite Work"].values * scalars_dict["Offsite work mult"]
-    )
-    offsite_efficiency = (
-        modules["Offsite Efficiency"].values * scalars_dict["Offsite efficiency mult"]
-    )
 
-    idx_modules = dfNewPlant.index.str.match(
-        "gggg"
-    )  # something I know will be all False
-    labor_savings = 0
-    for i, account in enumerate(accounts):
-        print("Modularizing account " + account)
-        idx = dfNewPlant.index.str.match(account)
-        idx_spec = dfNewPlant.index == (account)
-        dfNewPlant.loc[idx, "Factory Equipment Cost"] += dfNewPlant.loc[
-            idx, "Site Material Cost"
-        ]  # material costs are brought to the factory
-        dfNewPlant.loc[idx, "Factory Equipment Cost"] += (
-            offsite_work[i]
-            / offsite_efficiency[i]
-            * dfNewPlant.loc[idx, "Site Labor Cost"]
-        )  # 1/2 the labor is done in the factory at 2x the productivity
-        dfNewPlant.loc[idx, "Site Labor Cost"] *= (
-            1 - offsite_work[i]
-        )  # half of the labor is done onsite still
-        labor_savings += dfNewPlant.loc[idx, "Site Labor Hours"].sum() * (
-            1 - offsite_work[i]
-        )
-        dfNewPlant.loc[idx, "Site Labor Hours"] *= (
-            1 - offsite_work[i]
-        )  # half of the labor is done onsite still
-        dfNewPlant.loc[idx, "Site Material Cost"] = 0
-        dfNewPlant.loc[
-            idx, "Factory Equipment Cost"
-        ] *= 1.02  # transportation costs are 2% of direct costs
-        dfNewPlant.loc[idx_spec, "Factory Equipment Cost"] += (
-            fact_costs[i] / orders
-        )  # add in the cost of the factory
-        idx_modules = idx_modules | idx
-    print("Labor savings: " + str(labor_savings))
+    # Check if mass manufacturing mode is enabled
+    mass_mfg_enabled = scalars_dict.get("Enable Mass Manufacturing", False)
+
+    if mass_mfg_enabled:
+        print("Mass manufacturing mode enabled - applying enhanced factory assembly")
+
+        # Get mass manufacturing parameters
+        production_volume = scalars_dict.get("Production Volume", orders)
+        degree_factory = scalars_dict.get("Degree of Factory Assembly", 0.95)
+        factory_setup_cost = scalars_dict.get("Factory Setup Cost", 0)
+        mass_mfg_efficiency = scalars_dict.get("Mass Mfg Efficiency", 2.5)
+
+        # Apply mass manufacturing to ALL accounts (not just modular ones)
+        print(f"Applying {degree_factory*100:.1f}% factory assembly to all accounts")
+
+        idx_modules = dfNewPlant.index.str.match(".*")  # All accounts
+        labor_savings = 0
+
+        for account in dfNewPlant.index:
+            # Move material costs to factory
+            dfNewPlant.loc[account, "Factory Equipment Cost"] += dfNewPlant.loc[account, "Site Material Cost"]
+
+            # Move specified fraction of labor to factory with efficiency gain
+            labor_to_factory = degree_factory * dfNewPlant.loc[account, "Site Labor Cost"]
+            dfNewPlant.loc[account, "Factory Equipment Cost"] += labor_to_factory / mass_mfg_efficiency
+            dfNewPlant.loc[account, "Site Labor Cost"] *= (1 - degree_factory)
+
+            # Calculate labor savings
+            labor_savings += dfNewPlant.loc[account, "Site Labor Hours"] * degree_factory
+            dfNewPlant.loc[account, "Site Labor Hours"] *= (1 - degree_factory)
+
+            # Zero out site material costs
+            dfNewPlant.loc[account, "Site Material Cost"] = 0
+
+            # Add transportation costs
+            dfNewPlant.loc[account, "Factory Equipment Cost"] *= 1.02
+
+        # Add factory setup cost to first account only
+        first_account = dfNewPlant.index[0]
+        dfNewPlant.loc[first_account, "Factory Equipment Cost"] += factory_setup_cost / production_volume
+
+        print(f"Labor savings: {labor_savings:.0f} hours")
+        print(f"Factory setup cost per unit: ${factory_setup_cost/production_volume:,.0f}")
+
+    else:
+        # Run existing modularization logic
+        try:
+            modules = pd.read_excel(
+                pjoin(path, fname), header=0, sheet_name="Modules", index_col="Account"
+            )
+            accounts = modules.index
+            fact_costs = (
+                modules["Factory Cost (2018 USD)"].values * scalars_dict["Factory cost mult"]
+            )
+            offsite_work = (
+                modules["Percent Offsite Work"].values * scalars_dict["Offsite work mult"]
+            )
+            offsite_efficiency = (
+                modules["Offsite Efficiency"].values * scalars_dict["Offsite efficiency mult"]
+            )
+
+            idx_modules = dfNewPlant.index.str.match("gggg")  # Initialize as False
+            labor_savings = 0
+
+            for i, account in enumerate(accounts):
+                print("Modularizing account " + account)
+                idx = dfNewPlant.index.str.match(account)
+                idx_spec = dfNewPlant.index == (account)
+
+                dfNewPlant.loc[idx, "Factory Equipment Cost"] += dfNewPlant.loc[idx, "Site Material Cost"]
+                dfNewPlant.loc[idx, "Factory Equipment Cost"] += (
+                    offsite_work[i] / offsite_efficiency[i] * dfNewPlant.loc[idx, "Site Labor Cost"]
+                )
+                dfNewPlant.loc[idx, "Site Labor Cost"] *= (1 - offsite_work[i])
+                labor_savings += dfNewPlant.loc[idx, "Site Labor Hours"].sum() * (1 - offsite_work[i])
+                dfNewPlant.loc[idx, "Site Labor Hours"] *= (1 - offsite_work[i])
+                dfNewPlant.loc[idx, "Site Material Cost"] = 0
+                dfNewPlant.loc[idx, "Factory Equipment Cost"] *= 1.02
+                dfNewPlant.loc[idx_spec, "Factory Equipment Cost"] += (fact_costs[i] / orders)
+                idx_modules = idx_modules | idx
+
+            print("Labor savings: " + str(labor_savings))
+
+        except Exception as e:
+            print(f"No Modules sheet found, skipping modularization: {e}")
+            idx_modules = dfNewPlant.index.str.match("gggg")  # All False
 
     return dfNewPlant, idx_modules
+


### PR DESCRIPTION
## Summary
- add mass manufacturing parameters in fill_scaling_table
- implement optional mass-manufacturing modularize logic
- support mass manufacturing learning curves
- load mass manufacturing parameters in cost_model

## Testing
- `python -m compileall timcat`
- `python -m timcat.cli --help` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6885230506408328bda7eae51e4f136d