### PR TITLE
Add component-specific factory fractions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -51,7 +51,11 @@ Mass manufacturing can be activated by adding a ``MassManufacturing`` sheet to
 the input Excel file (see ``data/inputfile_MassManufacturing.xlsx`` for an
 example).  The sheet defines parameters such as ``Enable Mass Manufacturing``,
 production volume and factory setup cost used by the learning and
-modularization routines.
+modularization routines.  The mass manufacturing sheet can also define
+``Factory Fractions`` to override the default percentage of factory
+assembly for each component category (e.g. ``A.21:0.3,A.22:0.95``).  If not
+specified, TIMCAT uses built-in fractions reflecting the typical degree of
+factory fabrication for buildings, reactor equipment and other components.
 
 ## File descriptions
 All example input and configuration files are stored in the ``data``

--- a/timcat/cost_model.py
+++ b/timcat/cost_model.py
@@ -290,7 +290,7 @@ def run_ncet(
 
         # Modularize, learn, and build the scheduler table
         dfNP, idx_modules = modularize.modularize(
-            path, plant_fname, dfNP, orders, scalars_dict
+            path, plant_fname, dfNP, orders, scalars_dict, plant_characteristics
         )
         newPlant_list, learning_rate = learn.learn(
             path, plant_fname, dfNP, orders, scalars_dict, idx_modules

--- a/timcat/ncet/modularize.py
+++ b/timcat/ncet/modularize.py
@@ -2,8 +2,11 @@ import pandas as pd
 from os.path import join as pjoin
 
 
-def modularize(path, fname, dfNewPlant, orders, scalars_dict):
+def modularize(path, fname, dfNewPlant, orders, scalars_dict, plant_characteristics=None):
     print("Modularizing accounts")
+
+    if plant_characteristics is None:
+        plant_characteristics = {}
 
     # Check if mass manufacturing mode is enabled
     mass_mfg_enabled = scalars_dict.get("Enable Mass Manufacturing", False)
@@ -17,6 +20,36 @@ def modularize(path, fname, dfNewPlant, orders, scalars_dict):
         factory_setup_cost = scalars_dict.get("Factory Setup Cost", 0)
         mass_mfg_efficiency = scalars_dict.get("Mass Mfg Efficiency", 2.5)
 
+        # Define component-specific factory assembly fractions
+        factory_fractions = {
+            "A.21": 0.30,  # Buildings/Structures
+            "A.22": 0.95,  # Reactor Equipment
+            "A.23": 0.85,  # Turbine Equipment
+            "A.24": 0.90,  # Electrical Equipment
+            "A.25": 0.80,  # Miscellaneous Equipment
+            "A.26": 0.20,  # Heat Rejection
+        }
+
+        # Check if custom factory fractions are provided in input file
+        if "Factory Fractions" in plant_characteristics:
+            custom_fractions = plant_characteristics["Factory Fractions"]
+            if custom_fractions:
+                try:
+                    parsed = {
+                        k.strip(): float(v)
+                        for k, v in (item.split(":") for item in str(custom_fractions).split(","))
+                    }
+                    factory_fractions.update(parsed)
+                except Exception as e:
+                    print(f"Could not parse custom factory fractions: {e}")
+
+        print("Applying component-specific factory assembly:")
+        for prefix, fraction in factory_fractions.items():
+            print(f"  {prefix}: {fraction*100:.0f}% factory assembly")
+
+        # Track labor savings by category
+        labor_savings_by_category = {}
+
         # Apply mass manufacturing to ALL accounts (not just modular ones)
         print(f"Applying {degree_factory*100:.1f}% factory assembly to all accounts")
 
@@ -24,17 +57,27 @@ def modularize(path, fname, dfNewPlant, orders, scalars_dict):
         labor_savings = 0
 
         for account in dfNewPlant.index:
+            # Determine factory fraction based on account prefix
+            degree_factory_account = scalars_dict.get("Degree of Factory Assembly", 0.95)
+            for prefix, fraction in factory_fractions.items():
+                if account.startswith(prefix):
+                    degree_factory_account = fraction
+                    break
+
             # Move material costs to factory
             dfNewPlant.loc[account, "Factory Equipment Cost"] += dfNewPlant.loc[account, "Site Material Cost"]
 
             # Move specified fraction of labor to factory with efficiency gain
-            labor_to_factory = degree_factory * dfNewPlant.loc[account, "Site Labor Cost"]
+            labor_to_factory = degree_factory_account * dfNewPlant.loc[account, "Site Labor Cost"]
             dfNewPlant.loc[account, "Factory Equipment Cost"] += labor_to_factory / mass_mfg_efficiency
-            dfNewPlant.loc[account, "Site Labor Cost"] *= (1 - degree_factory)
+            dfNewPlant.loc[account, "Site Labor Cost"] *= (1 - degree_factory_account)
 
-            # Calculate labor savings
-            labor_savings += dfNewPlant.loc[account, "Site Labor Hours"] * degree_factory
-            dfNewPlant.loc[account, "Site Labor Hours"] *= (1 - degree_factory)
+            # Calculate labor savings and track per category
+            category = account[:4]
+            labor_savings += dfNewPlant.loc[account, "Site Labor Hours"] * degree_factory_account
+            labor_savings_by_category.setdefault(category, 0)
+            labor_savings_by_category[category] += dfNewPlant.loc[account, "Site Labor Hours"] * degree_factory_account
+            dfNewPlant.loc[account, "Site Labor Hours"] *= (1 - degree_factory_account)
 
             # Zero out site material costs
             dfNewPlant.loc[account, "Site Material Cost"] = 0
@@ -47,6 +90,8 @@ def modularize(path, fname, dfNewPlant, orders, scalars_dict):
         dfNewPlant.loc[first_account, "Factory Equipment Cost"] += factory_setup_cost / production_volume
 
         print(f"Labor savings: {labor_savings:.0f} hours")
+        for cat, hours in labor_savings_by_category.items():
+            print(f"  {cat}: {hours:.0f} hours saved")
         print(f"Factory setup cost per unit: ${factory_setup_cost/production_volume:,.0f}")
 
     else:


### PR DESCRIPTION
## Summary
- extend `modularize` to accept `plant_characteristics`
- implement component-specific factory assembly fractions with optional overrides
- track labor savings per component category
- pass new argument from `cost_model`
- document configuration of factory fractions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68852ac11d448328b0fc00f90da3faef